### PR TITLE
add asyncSelector to configuration api

### DIFF
--- a/applitools.config.js
+++ b/applitools.config.js
@@ -6,4 +6,4 @@ try {
   config = require('./applitools.private.config.js');
 } catch (e) {}
 
-module.exports = applitoolsConfig({config});
+module.exports = applitoolsConfig({config, asyncSelector: true});

--- a/config/applitools.config.js
+++ b/config/applitools.config.js
@@ -45,10 +45,10 @@ function getServerUrl() {
   return serverUrlConfig;
 }
 
-module.exports = ({config}) => merge({
+module.exports = ({config, asyncSelector}) => merge({
   apiKey: process.env.EYES_API_KEY,
   batchId: getBatchId(),
   batchName: process.env.npm_package_name,
   exitcode: true,
-  waitBeforeScreenshots: `[${DATA_READY_HOOK}="true"]`,
+  waitBeforeScreenshots: asyncSelector === true ? `[${DATA_READY_HOOK}="true"]` : asyncSelector,
 }, getServerUrl(), config);


### PR DESCRIPTION
I'm not 100% sure about this.
We need someway to let users disable async testing (i.e. disabling the waitBeforeScreenshots selector).
I'm not exactly sure this is the best way.
Theoretically it can be overriden using the `config` object that is passed, but the only way to override it is by passing a number or a different selector or function.